### PR TITLE
Making some fields required to reduce validating complexity and improve clarity

### DIFF
--- a/operator/api/v1alpha2/seldondeployment_types.go
+++ b/operator/api/v1alpha2/seldondeployment_types.go
@@ -197,15 +197,15 @@ func GetContainerServiceName(mlDep *SeldonDeployment, predictorSpec PredictorSpe
 // SeldonDeploymentSpec defines the desired state of SeldonDeployment
 type SeldonDeploymentSpec struct {
 	Name        string            `json:"name,omitempty" protobuf:"string,1,opt,name=name"`
-	Predictors  []PredictorSpec   `json:"predictors,omitempty" protobuf:"bytes,2,opt,name=name"`
+	Predictors  []PredictorSpec   `json:"predictors" protobuf:"bytes,2,opt,name=name"`
 	OauthKey    string            `json:"oauth_key,omitempty" protobuf:"string,3,opt,name=oauth_key"`
 	OauthSecret string            `json:"oauth_secret,omitempty" protobuf:"string,4,opt,name=oauth_secret"`
 	Annotations map[string]string `json:"annotations,omitempty" protobuf:"bytes,5,opt,name=annotations"`
 }
 
 type PredictorSpec struct {
-	Name            string                  `json:"name,omitempty" protobuf:"string,1,opt,name=name"`
-	Graph           *PredictiveUnit         `json:"graph,omitempty" protobuf:"bytes,2,opt,name=predictiveUnit"`
+	Name            string                  `json:"name" protobuf:"string,1,opt,name=name"`
+	Graph           *PredictiveUnit         `json:"graph" protobuf:"bytes,2,opt,name=predictiveUnit"`
 	ComponentSpecs  []*SeldonPodSpec        `json:"componentSpecs,omitempty" protobuf:"bytes,3,opt,name=componentSpecs"`
 	Replicas        int32                   `json:"replicas,omitempty" protobuf:"string,4,opt,name=replicas"`
 	Annotations     map[string]string       `json:"annotations,omitempty" protobuf:"bytes,5,opt,name=annotations"`
@@ -239,7 +239,7 @@ type SeldonPodSpec struct {
 
 type SeldonHpaSpec struct {
 	MinReplicas *int32                          `json:"minReplicas,omitempty" protobuf:"int,1,opt,name=minReplicas"`
-	MaxReplicas int32                           `json:"maxReplicas,omitempty" protobuf:"int,2,opt,name=maxReplicas"`
+	MaxReplicas int32                           `json:"maxReplicas" protobuf:"int,2,opt,name=maxReplicas"`
 	Metrics     []autoscalingv2beta2.MetricSpec `json:"metrics,omitempty" protobuf:"bytes,3,opt,name=metrics"`
 }
 
@@ -302,13 +302,13 @@ const (
 )
 
 type Parameter struct {
-	Name  string       `json:"name,omitempty" protobuf:"string,1,opt,name=name"`
-	Value string       `json:"value,omitempty" protobuf:"string,2,opt,name=value"`
-	Type  ParmeterType `json:"type,omitempty" protobuf:"int,3,opt,name=type"`
+	Name  string       `json:"name" protobuf:"string,1,opt,name=name"`
+	Value string       `json:"value" protobuf:"string,2,opt,name=value"`
+	Type  ParmeterType `json:"type" protobuf:"int,3,opt,name=type"`
 }
 
 type PredictiveUnit struct {
-	Name               string                        `json:"name,omitempty" protobuf:"string,1,opt,name=name"`
+	Name               string                        `json:"name" protobuf:"string,1,opt,name=name"`
 	Children           []PredictiveUnit              `json:"children,omitempty" protobuf:"bytes,2,opt,name=children"`
 	Type               *PredictiveUnitType           `json:"type,omitempty" protobuf:"int,3,opt,name=type"`
 	Implementation     *PredictiveUnitImplementation `json:"implementation,omitempty" protobuf:"int,4,opt,name=implementation"`

--- a/operator/config/crd/bases/machinelearning.seldon.io_seldondeployments.yaml
+++ b/operator/config/crd/bases/machinelearning.seldon.io_seldondeployments.yaml
@@ -362,6 +362,8 @@ spec:
                             minReplicas:
                               format: int32
                               type: integer
+                          required:
+                          - maxReplicas
                           type: object
                         metadata:
                           type: object
@@ -5865,12 +5867,18 @@ spec:
                               type: string
                             value:
                               type: string
+                          required:
+                          - name
+                          - type
+                          - value
                           type: object
                         type: array
                       serviceAccountName:
                         type: string
                       type:
                         type: string
+                    required:
+                    - name
                     type: object
                   labels:
                     additionalProperties:
@@ -6014,8 +6022,13 @@ spec:
                   traffic:
                     format: int32
                     type: integer
+                required:
+                - graph
+                - name
                 type: object
               type: array
+          required:
+          - predictors
           type: object
         status:
           description: SeldonDeploymentStatus defines the observed state of SeldonDeployment


### PR DESCRIPTION

Using information in https://docs.seldon.io/projects/seldon-core/en/latest/reference/seldon-deployment.html and general knowledge of the design, I propose to mark these fields required.  The CRD spec is auto-updated to reflect these required status and can reduce the complexity in validating webhook as well as making it easier to see what is important and what is not.

This is my first pass, there might be fields that I think is required but not, or fields that should be required but I missed.